### PR TITLE
Adds splitAt method to TimeSeries

### DIFF
--- a/shared/src/main/scala/carldata/series/TimeSeries.scala
+++ b/shared/src/main/scala/carldata/series/TimeSeries.scala
@@ -305,14 +305,13 @@ case class TimeSeries[V](idx: Vector[Instant], ds: Vector[V]) {
     */
   def splitAt(g: Instant): (TimeSeries[V], TimeSeries[V]) = {
     val ordered = this.sortByIndex
-    val indexOpt = ordered.index.zipWithIndex.find(_._1.compareTo(g) >= 0).map(_._2)
+    val iOpt = ordered.index.zipWithIndex.find(_._1.compareTo(g) >= 0).map(_._2)
 
-    indexOpt match {
+    iOpt match {
       case None => (ordered, TimeSeries.empty)
-      case Some(index) =>
-        val i = ordered.index.splitAt(index)
-        val v = ordered.values.splitAt(index)
-        (new TimeSeries(i._1, v._1), new TimeSeries(i._2, v._2))
+      case Some(i) =>
+        val ds = ordered.dataPoints.splitAt(i)
+        (new TimeSeries(ds._1), new TimeSeries(ds._2))
     }
   }
 

--- a/shared/src/main/scala/carldata/series/TimeSeries.scala
+++ b/shared/src/main/scala/carldata/series/TimeSeries.scala
@@ -298,6 +298,11 @@ case class TimeSeries[V](idx: Vector[Instant], ds: Vector[V]) {
     new TimeSeries(d)
   }
 
+  /**
+    * Get tuple of series with right side inclusive to the requested split instant.
+    *
+    * @param g Instant to split the series
+    */
   def splitAt(g: Instant): (TimeSeries[V], TimeSeries[V]) = {
     val ordered = this.sortByIndex
     val indexOpt = ordered.index.zipWithIndex.find(_._1.compareTo(g) >= 0).map(_._2)

--- a/shared/src/main/scala/carldata/series/TimeSeries.scala
+++ b/shared/src/main/scala/carldata/series/TimeSeries.scala
@@ -22,7 +22,7 @@ object TimeSeries {
 
   /** Return new series by interpolate missing points */
   def interpolate[V: Numeric](xs: TimeSeries[V], delta: Duration)(implicit num: Fractional[V]): TimeSeries[V] = {
-    def f(x1: (Instant, V), x2: (Instant, V), tsh: Instant) = {
+    def f(x1: (Instant, V), x2: (Instant, V), tsh: Instant): V = {
       val tx = num.fromInt(Duration.between(tsh, x1._1).toMillis.toInt)
       val ty = num.fromInt(Duration.between(tsh, x2._1).toMillis.toInt)
       num.plus(num.times(num.div(ty, num.plus(tx, ty)), x1._2), num.times(num.div(tx, num.plus(tx, ty)), x2._2))
@@ -77,7 +77,7 @@ object TimeSeries {
 
   /**
     * Predictive overflow based on the assumption that
-    * if the next value is smaller then the current value, then overflow happend
+    * if the next value is smaller then the current value, then overflow happened
     */
   def diffOverflow[V: Numeric](ts: TimeSeries[V])(implicit num: Numeric[V]): TimeSeries[V] = {
     if (ts.isEmpty) ts
@@ -169,6 +169,7 @@ object TimeSeries {
       (acc, x) => acc.join(x).mapValues(y => y._1 :+ y._2)
     }
   }
+
 }
 
 /**
@@ -222,7 +223,6 @@ case class TimeSeries[V](idx: Vector[Instant], ds: Vector[V]) {
       v <- values.lastOption
     } yield (i, v)
   }
-
 
   /** Return new Time Series where index is always increasing */
   def sortByIndex: TimeSeries[V] = {
@@ -363,7 +363,7 @@ case class TimeSeries[V](idx: Vector[Instant], ds: Vector[V]) {
     * Resample series. If there are any missing points then they will be replaced by given default value
     */
   def resampleWithDefault(delta: Duration, default: V)(implicit num: Fractional[V]): TimeSeries[V] = {
-    def f(x1: (Instant, V), x2: (Instant, V), tsh: Instant) = default
+    def f(x1: (Instant, V), x2: (Instant, V), tsh: Instant): V = default
 
     resample(delta, f)
   }
@@ -514,5 +514,5 @@ case class TimeSeries[V](idx: Vector[Instant], ds: Vector[V]) {
 
     new TimeSeries(joinR(dataPoints, ts.dataPoints))
   }
-}
 
+}

--- a/shared/src/test/scala/carldata/series/TimeSeriesTest.scala
+++ b/shared/src/test/scala/carldata/series/TimeSeriesTest.scala
@@ -119,12 +119,10 @@ class TimeSeriesTest extends FlatSpec with Matchers {
 
   it should "return expected series when splitted" in {
     val series: TimeSeries[Int] = TimeSeries.fromTimestamps(Seq((1, 1), (2, -3), (3, 6), (4, 6), (5, 6), (6, 6)))
-    series.index.zipWithIndex.foreach {
-      case (i, index) =>
-        val (a, b) = series.splitAt(i)
-        a.length shouldBe index
-        b.length shouldBe series.length - index
-    }
+    val expected: (TimeSeries[Int], TimeSeries[Int]) = (TimeSeries.fromTimestamps(Seq((1, 1), (2, -3), (3, 6))),
+      TimeSeries.fromTimestamps(Seq((4, 6), (5, 6), (6, 6))))
+    val splitted = series.splitAt(Instant.ofEpochSecond(4))
+    splitted shouldBe expected
   }
 
   it should "take first n element" in {

--- a/shared/src/test/scala/carldata/series/TimeSeriesTest.scala
+++ b/shared/src/test/scala/carldata/series/TimeSeriesTest.scala
@@ -190,7 +190,7 @@ class TimeSeriesTest extends FlatSpec with Matchers {
     val series = TimeSeries(idx, Vector(1, 2, 3, 4, 5))
     val expected = TimeSeries(Vector(now, now.plusSeconds(60)), Vector(6, 9))
 
-    series.groupByTime(_.truncatedTo(ChronoUnit.MINUTES), _.map(_._2).sum) shouldBe expected
+    series.groupByTime(_.truncatedTo(ChronoUnit.MINUTES), _.unzip._2.sum) shouldBe expected
   }
 
   it should "group by hour" in {
@@ -205,7 +205,7 @@ class TimeSeriesTest extends FlatSpec with Matchers {
       , now.plusSeconds(2 * day), now.plusSeconds(2 * day + 10), now.plusSeconds(2 * day + 20))
     val series = TimeSeries(idx, Vector(1, 2, 3, 1, 2, 3, 1, 2, 4))
     val expected = TimeSeries(Vector(now, now.plusSeconds(10), now.plusSeconds(20)), Vector(3, 6, 10))
-    series.groupByTime(groupHours, _.map(_._2).sum) shouldBe expected
+    series.groupByTime(groupHours, _.unzip._2.sum) shouldBe expected
   }
 
   it should "find sum in rolling windows operation" in {
@@ -498,7 +498,7 @@ class TimeSeriesTest extends FlatSpec with Matchers {
     val now = Instant.EPOCH
     val idx = Vector(now, now.plusSeconds(10), now.plusSeconds(20), now.plusSeconds(60), now.plusSeconds(80))
     val series = TimeSeries(idx, Vector(1, 2f, 3f, 4f, 5f))
-    val expected = Duration.of(10L, ChronoUnit.SECONDS)
+    val expected = Duration.of(10l, ChronoUnit.SECONDS)
     series.resolution shouldBe expected
   }
 

--- a/shared/src/test/scala/carldata/series/TimeSeriesTest.scala
+++ b/shared/src/test/scala/carldata/series/TimeSeriesTest.scala
@@ -168,7 +168,7 @@ class TimeSeriesTest extends FlatSpec with Matchers {
     val series = TimeSeries(idx, Vector(1, 2, 3, 4, 5))
     val expected = TimeSeries(Vector(now, now.plusSeconds(60)), Vector(6, 9))
 
-    series.groupByTime(_.truncatedTo(ChronoUnit.MINUTES), _.unzip._2.sum) shouldBe expected
+    series.groupByTime(_.truncatedTo(ChronoUnit.MINUTES), _.map(_._2).sum) shouldBe expected
   }
 
   it should "group by hour" in {
@@ -183,7 +183,7 @@ class TimeSeriesTest extends FlatSpec with Matchers {
       , now.plusSeconds(2 * day), now.plusSeconds(2 * day + 10), now.plusSeconds(2 * day + 20))
     val series = TimeSeries(idx, Vector(1, 2, 3, 1, 2, 3, 1, 2, 4))
     val expected = TimeSeries(Vector(now, now.plusSeconds(10), now.plusSeconds(20)), Vector(3, 6, 10))
-    series.groupByTime(groupHours, _.unzip._2.sum) shouldBe expected
+    series.groupByTime(groupHours, _.map(_._2).sum) shouldBe expected
   }
 
   it should "find sum in rolling windows operation" in {
@@ -476,7 +476,7 @@ class TimeSeriesTest extends FlatSpec with Matchers {
     val now = Instant.EPOCH
     val idx = Vector(now, now.plusSeconds(10), now.plusSeconds(20), now.plusSeconds(60), now.plusSeconds(80))
     val series = TimeSeries(idx, Vector(1, 2f, 3f, 4f, 5f))
-    val expected = Duration.of(10l, ChronoUnit.SECONDS)
+    val expected = Duration.of(10L, ChronoUnit.SECONDS)
     series.resolution shouldBe expected
   }
 

--- a/shared/src/test/scala/carldata/series/TimeSeriesTest.scala
+++ b/shared/src/test/scala/carldata/series/TimeSeriesTest.scala
@@ -105,6 +105,28 @@ class TimeSeriesTest extends FlatSpec with Matchers {
     series.slice(start, end).length shouldBe 4
   }
 
+  it should "return same series on right side when splitted at an instant smaller than its first instant" in {
+    val series: TimeSeries[Int] = TimeSeries.fromTimestamps(Seq((2, -3), (3, 6), (4, 6), (5, 6), (6, 6), (7, 3)))
+    val splitted = series.splitAt(Instant.ofEpochSecond(1))
+    splitted shouldBe (TimeSeries.empty, series)
+  }
+
+  it should "return same series on left side when splitted at an instant greater than its last instant" in {
+    val series: TimeSeries[Int] = TimeSeries.fromTimestamps(Seq((1, 1), (2, -3), (3, 6), (4, 6), (5, 6), (6, 6)))
+    val splitted = series.splitAt(Instant.ofEpochSecond(7))
+    splitted shouldBe (series, TimeSeries.empty)
+  }
+
+  it should "return expected series when splitted" in {
+    val series: TimeSeries[Int] = TimeSeries.fromTimestamps(Seq((1, 1), (2, -3), (3, 6), (4, 6), (5, 6), (6, 6)))
+    series.index.zipWithIndex.foreach {
+      case (i, index) =>
+        val (a, b) = series.splitAt(i)
+        a.length shouldBe index
+        b.length shouldBe series.length - index
+    }
+  }
+
   it should "take first n element" in {
     val series: TimeSeries[Int] = TimeSeries.fromTimestamps(Seq((1, 1), (2, -3), (3, 6), (4, 6), (5, 6), (6, 6)))
     val expected: TimeSeries[Int] = TimeSeries.fromTimestamps(Seq((1, 1), (2, -3), (3, 6), (4, 6)))


### PR DESCRIPTION
https://github.com/carldata/timeseries/issues/136

It follows the same idea used on python's numpy, splitting at instant greater or equal to te requested one. To guarantee time order, has to order it first because for what I've seen this TimeSeries does not guarantee order while constructing it.